### PR TITLE
feat(admin): add member rename action

### DIFF
--- a/src/components/admin/Members.tsx
+++ b/src/components/admin/Members.tsx
@@ -4,7 +4,9 @@ import Error from '@/components/core/Error'
 import Image from '@/components/core/Image'
 import SearchBar from '@/components/core/SearchBar'
 import Table from '@/components/core/Table'
+import { DropdownMenu, DropdownMenuItem } from '@/components/core/DropdownMenu'
 import CheckBox from '@/components/form/base/CheckBox'
+import { useFormDialog } from '@/components/form/FormDialog'
 import trpc from '@/lib/client/trpc'
 import { settings } from '@/lib/common'
 import { twMerge } from 'tailwind-merge'
@@ -14,12 +16,17 @@ export default function Members() {
   // State
   const [searchKeyword, setSearchKeyword] = useState<string>('')
   const [showDeactivated, setShowDeactivated] = useState<boolean>(false)
+  const { showFormDialog, formDialog } = useFormDialog()
 
   // Trpc
   const { data, isError, error } = trpc.user.getStatistics.useQuery({
     showDeactivated,
   })
+  const currentUserQuery = trpc.user.get.useQuery(undefined)
+  const utils = trpc.useUtils()
   const updateUserAuthority = trpc.user.updateAuthority.useMutation()
+  const isAdmin = currentUserQuery.data?.role === 'ADMIN'
+  type Member = NonNullable<typeof data>[number]
 
   const filteredMembers = useMemo(() => {
     if (!data) return []
@@ -39,6 +46,44 @@ export default function Members() {
       })
     },
     [updateUserAuthority],
+  )
+
+  const handleMemberNameUpdate = useCallback(
+    (user: Member) => {
+      showFormDialog({
+        title: '更改名稱',
+        inputs: {
+          name: {
+            label: '名稱',
+            type: 'text',
+            defaultValue: user.name,
+            attributes: {
+              autoFocus: true,
+              maxLength: 100,
+            },
+            options: {
+              required: '名稱不可為空',
+              validate: (value) => value.trim() !== '' || '名稱不可為空',
+            },
+          },
+        },
+        useMutation: trpc.user.updateName.useMutation,
+        onSubmit(formData, mutation) {
+          mutation.mutate(
+            {
+              userId: user.id,
+              name: formData.name,
+            },
+            {
+              onSuccess: () => {
+                utils.user.getStatistics.invalidate()
+              },
+            },
+          )
+        },
+      })
+    },
+    [showFormDialog, utils.user.getStatistics],
   )
 
   if (isError) return <Error description={error.message} />
@@ -168,8 +213,29 @@ export default function Members() {
                   '啟用中'
                 ),
             },
+            ...(isAdmin
+              ? [
+                  {
+                    name: '動作',
+                    align: 'left' as const,
+                    cellClassName: 'text-sm',
+                    render: (user: Member) => (
+                      <DropdownMenu
+                        className='rounded-2xl bg-stone-100 px-3 py-1 text-sm text-stone-600 hover:bg-stone-200 active:scale-90'
+                        label='動作'
+                      >
+                        <DropdownMenuItem
+                          label='更改名稱'
+                          onClick={() => handleMemberNameUpdate(user)}
+                        />
+                      </DropdownMenu>
+                    ),
+                  },
+                ]
+              : []),
           ]}
         />
+        {formDialog}
       </div>
     </div>
   )

--- a/src/components/overlays/EventListener.tsx
+++ b/src/components/overlays/EventListener.tsx
@@ -251,6 +251,7 @@ export function EventListenerBase() {
           utils.commodity.getList.invalidate()
           break
         case PUSHER_EVENT.USER_AUTHORIY_UPDATE:
+        case PUSHER_EVENT.USER_UPDATE:
           utils.user.get.invalidate()
           utils.user.getStatistics.invalidate()
           break

--- a/src/lib/common/pusher.ts
+++ b/src/lib/common/pusher.ts
@@ -66,6 +66,7 @@ export enum PUSHER_EVENT {
   USER_TEST_PUSH_NOTIFICATION = '測試推送通知',
   USER_TOKEN_UPDATE = '用戶裝置設定已更改',
   USER_AUTHORIY_UPDATE = '用戶權限已更改',
+  USER_UPDATE = '用戶資料已更改',
 }
 
 // Webhook event types

--- a/src/lib/server/database/user.ts
+++ b/src/lib/server/database/user.ts
@@ -611,3 +611,32 @@ export async function updateUserAuthority(props: {
     },
   })
 }
+
+export async function updateUserName(props: { userId: string; name: string }) {
+  const existingUser = await prisma.user.findUnique({
+    where: {
+      id: props.userId,
+    },
+    select: {
+      id: true,
+    },
+  })
+
+  if (!existingUser) {
+    throw new Error('使用者不存在')
+  }
+
+  const user = await prisma.user.update({
+    where: {
+      id: props.userId,
+    },
+    data: {
+      name: props.name,
+    },
+    select: {
+      name: true,
+    },
+  })
+
+  return user
+}

--- a/src/lib/trpc/api/user.ts
+++ b/src/lib/trpc/api/user.ts
@@ -10,6 +10,7 @@ import {
   getUsersStatistics,
   getUserToken,
   updateUserAuthority,
+  updateUserName,
   updateUserSettings,
   updateUserToken,
   validateUserPassword,
@@ -20,7 +21,13 @@ import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 
 import { UserAuthority } from '@prisma/client'
-import { commonProcedure, router, staffProcedure, userProcedure } from '../trpc'
+import {
+  adminProcedure,
+  commonProcedure,
+  router,
+  staffProcedure,
+  userProcedure,
+} from '../trpc'
 
 type UserAdData = {
   group: string[]
@@ -240,6 +247,25 @@ export const UserRouter = router({
       emitPusherEvent(PUSHER_CHANNEL.USER(input.userId), {
         type: PUSHER_EVENT.USER_AUTHORIY_UPDATE,
         message: `您${updateMessage}`,
+      })
+    }),
+  updateName: adminProcedure
+    .input(
+      z.object({
+        userId: z.string(),
+        name: z.string().trim().min(1, '名稱不可為空').max(100, '名稱過長'),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const user = await updateUserName(input)
+
+      emitPusherEvent(PUSHER_CHANNEL.STAFF, {
+        type: PUSHER_EVENT.USER_UPDATE,
+        message: `用戶名稱已更改為 ${user.name}`,
+      })
+      emitPusherEvent(PUSHER_CHANNEL.USER(input.userId), {
+        type: PUSHER_EVENT.USER_UPDATE,
+        message: `您的名稱已更改為 ${user.name}`,
       })
     }),
 })

--- a/src/lib/trpc/trpc.ts
+++ b/src/lib/trpc/trpc.ts
@@ -105,3 +105,15 @@ export const staffProcedure = userProcedure.use(
     return next({ ctx: { userLite: ctx.userLite! } })
   }),
 )
+
+export const adminProcedure = userProcedure.use(
+  t.middleware(async ({ next, ctx }) => {
+    if (!ctx.userLite || !validateRole(ctx.userLite.role, UserRole.ADMIN)) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: '未授權',
+      })
+    }
+    return next({ ctx: { userLite: ctx.userLite! } })
+  }),
+)


### PR DESCRIPTION
## Summary
Add an ADMIN-only member action menu with a `更改名稱` flow so staff can manage user display names from the members table. The new TRPC mutation updates the canonical `User.name` field and broadcasts an update event so member data refreshes across clients.

## Changes
- Add `adminProcedure` in `src/lib/trpc/trpc.ts` and use it to guard the new rename mutation
- Add `updateUserName` in `src/lib/server/database/user.ts` with explicit not-found handling
- Add `trpc.user.updateName` in `src/lib/trpc/api/user.ts` with trim/non-empty/max-length validation
- Add `USER_UPDATE` Pusher invalidation handling in `src/lib/common/pusher.ts` and `src/components/overlays/EventListener.tsx`
- Update `src/components/admin/Members.tsx` to show an ADMIN-only `動作` dropdown with `更改名稱`

## Why / Context
Keep the current first action narrow while leaving room for future member actions in the same trailing dropdown column. The implementation stays aligned with the existing admin patterns in the app by reusing the form dialog and dropdown menu primitives.

## Testing
- `pnpm exec tsc --noEmit` passed
- Manual browser check against `http://localhost:8086/admin/members` returned `200`
- `pnpm build` reached type-checking and compilation successfully; the final trace-collection step failed on an existing `.next` artifact lookup while the local dev server was running

## Screenshots / Recordings
Not run (not requested)

## Related

## Checklist
- [x] Title follows Conventional Commits
- [x] Tests added or updated (or N/A explained)
- [x] No unrelated changes mixed in
- [x] Breaking changes documented and migration path provided
- [x] Docs / changelog updated if user-facing